### PR TITLE
Add Market Event Watcher demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-# hello-world
-This is my first repository
-I am trying to learn Github
-Readme is a new brach                                                                                                                                                                                                                                                                                
+# Market Event Watcher
+
+Market Event Watcher is a lightweight demo app for searching upcoming stock market events and creating alerts for the ones that matter most.
+
+## Features
+- Search events by keyword, symbol, category, and time window.
+- View upcoming earnings, macro releases, guidance updates, and dividend events.
+- Create and manage alerts for specific symbols or events.
+
+## Run the app
+1. Open `index.html` in your browser.
+2. Use the search filters to find relevant market events.
+3. Add alerts directly from results or create custom alerts.
+
+## Next steps
+Connect the UI to a real data provider, hook alerts into email/SMS notifications, and persist alerts in a database.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,214 @@
+const events = [
+  {
+    id: 1,
+    title: "AAPL Q3 Earnings Call",
+    symbol: "AAPL",
+    category: "earnings",
+    date: "2024-08-01",
+    summary: "Consensus EPS: $1.31 | Revenue: $82.1B",
+  },
+  {
+    id: 2,
+    title: "FOMC Rate Decision",
+    symbol: "FED",
+    category: "macro",
+    date: "2024-08-05",
+    summary: "Rate decision with press conference",
+  },
+  {
+    id: 3,
+    title: "TSLA Delivery Update",
+    symbol: "TSLA",
+    category: "guidance",
+    date: "2024-08-12",
+    summary: "Focus on margin commentary and deliveries",
+  },
+  {
+    id: 4,
+    title: "MSFT Dividend Record Date",
+    symbol: "MSFT",
+    category: "dividend",
+    date: "2024-08-15",
+    summary: "Dividend: $0.75 per share",
+  },
+  {
+    id: 5,
+    title: "NVDA Q2 Earnings",
+    symbol: "NVDA",
+    category: "earnings",
+    date: "2024-08-20",
+    summary: "Watch data center growth and AI demand",
+  },
+  {
+    id: 6,
+    title: "GDP Advance Release",
+    symbol: "US",
+    category: "macro",
+    date: "2024-08-25",
+    summary: "First estimate of GDP for the quarter",
+  },
+];
+
+const alerts = [];
+
+const searchForm = document.querySelector("#search-form");
+const resultsContainer = document.querySelector("#results");
+const resultsCount = document.querySelector("#results-count");
+const alertForm = document.querySelector("#alert-form");
+const alertList = document.querySelector("#alerts");
+const alertCount = document.querySelector("#alert-count");
+
+const formatDate = (date) =>
+  new Date(date).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+const daysUntil = (date) => {
+  const now = new Date();
+  const target = new Date(date);
+  const diffTime = target.getTime() - now.setHours(0, 0, 0, 0);
+  return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+};
+
+const renderEvents = (filtered) => {
+  resultsContainer.innerHTML = "";
+  resultsCount.textContent = `${filtered.length} events`;
+
+  if (filtered.length === 0) {
+    resultsContainer.innerHTML =
+      "<p class=\"meta\">No events found. Try expanding your search.</p>";
+    return;
+  }
+
+  filtered.forEach((event) => {
+    const card = document.createElement("div");
+    card.className = "card";
+    card.innerHTML = `
+      <div class="pill">${event.symbol} · ${event.category}</div>
+      <strong>${event.title}</strong>
+      <div class="meta">${formatDate(event.date)} · ${event.summary}</div>
+      <div class="actions">
+        <span class="meta">${daysUntil(event.date)} days away</span>
+        <button data-id="${event.id}">Add alert</button>
+      </div>
+    `;
+    card.querySelector("button").addEventListener("click", () => {
+      addAlertFromEvent(event);
+    });
+    resultsContainer.appendChild(card);
+  });
+};
+
+const renderAlerts = () => {
+  alertList.innerHTML = "";
+  alertCount.textContent = `${alerts.length} alerts`;
+
+  if (alerts.length === 0) {
+    alertList.innerHTML =
+      "<p class=\"meta\">No alerts yet. Add one from a search result or create your own.</p>";
+    return;
+  }
+
+  alerts.forEach((alert) => {
+    const card = document.createElement("div");
+    card.className = "card alert-card";
+    card.innerHTML = `
+      <div class="pill">${alert.symbol} · ${alert.type}</div>
+      <strong>Notify ${alert.window} day(s) before ${alert.title}</strong>
+      <div class="meta">Scheduled: ${formatDate(alert.date)}</div>
+      <div class="actions">
+        <span class="meta">${alert.notes}</span>
+        <button data-id="${alert.id}">Remove</button>
+      </div>
+    `;
+    card.querySelector("button").addEventListener("click", () => {
+      removeAlert(alert.id);
+    });
+    alertList.appendChild(card);
+  });
+};
+
+const filterEvents = ({ keyword, category, range }) => {
+  const keywordLower = keyword.trim().toLowerCase();
+  const windowDays = Number(range);
+
+  return events.filter((event) => {
+    const matchesKeyword =
+      keywordLower.length === 0 ||
+      event.title.toLowerCase().includes(keywordLower) ||
+      event.symbol.toLowerCase().includes(keywordLower);
+    const matchesCategory = category === "all" || event.category === category;
+    const withinRange = daysUntil(event.date) <= windowDays;
+
+    return matchesKeyword && matchesCategory && withinRange;
+  });
+};
+
+const addAlertFromEvent = (event) => {
+  const existing = alerts.find(
+    (alert) => alert.symbol === event.symbol && alert.type === event.category
+  );
+  if (existing) {
+    existing.notes = "Already watching this event";
+    renderAlerts();
+    return;
+  }
+
+  alerts.push({
+    id: Date.now(),
+    symbol: event.symbol,
+    type: event.category,
+    window: 3,
+    title: event.title,
+    date: event.date,
+    notes: "Created from search results",
+  });
+
+  renderAlerts();
+};
+
+const removeAlert = (id) => {
+  const index = alerts.findIndex((alert) => alert.id === id);
+  if (index >= 0) {
+    alerts.splice(index, 1);
+    renderAlerts();
+  }
+};
+
+searchForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const keyword = document.querySelector("#keyword").value;
+  const category = document.querySelector("#category").value;
+  const range = document.querySelector("#date-range").value;
+  const filtered = filterEvents({ keyword, category, range });
+  renderEvents(filtered);
+});
+
+alertForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const symbol = document.querySelector("#alert-symbol").value.trim().toUpperCase();
+  const type = document.querySelector("#alert-type").value;
+  const window = document.querySelector("#alert-window").value;
+
+  if (!symbol) {
+    return;
+  }
+
+  alerts.push({
+    id: Date.now(),
+    symbol,
+    type,
+    window,
+    title: `${symbol} ${type}`,
+    date: new Date().toISOString(),
+    notes: "Custom alert created",
+  });
+
+  alertForm.reset();
+  renderAlerts();
+});
+
+renderEvents(filterEvents({ keyword: "", category: "all", range: 30 }));
+renderAlerts();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Market Event Watcher</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <div>
+      <p class="eyebrow">Market Insights</p>
+      <h1>Market Event Watcher</h1>
+      <p class="subtitle">Search upcoming market events and set alerts for the ones that move your portfolio.</p>
+    </div>
+    <div class="hero-card">
+      <h2>Today at a glance</h2>
+      <ul>
+        <li><strong>12</strong> events tracked</li>
+        <li><strong>4</strong> alerts active</li>
+        <li><strong>6</strong> symbols monitored</li>
+      </ul>
+    </div>
+  </header>
+
+  <main>
+    <section class="panel">
+      <h2>Search market events</h2>
+      <form id="search-form" class="search-form">
+        <label>
+          Keyword or symbol
+          <input type="text" id="keyword" placeholder="e.g. earnings, AAPL" />
+        </label>
+        <label>
+          Category
+          <select id="category">
+            <option value="all">All events</option>
+            <option value="earnings">Earnings</option>
+            <option value="macro">Macro</option>
+            <option value="guidance">Guidance</option>
+            <option value="dividend">Dividends</option>
+          </select>
+        </label>
+        <label>
+          Date range
+          <select id="date-range">
+            <option value="7">Next 7 days</option>
+            <option value="30">Next 30 days</option>
+            <option value="90">Next 90 days</option>
+          </select>
+        </label>
+        <button type="submit">Search events</button>
+      </form>
+
+      <div class="results-header">
+        <h3>Results</h3>
+        <span id="results-count">0</span>
+      </div>
+      <div id="results" class="results"></div>
+    </section>
+
+    <section class="panel">
+      <h2>Create an alert</h2>
+      <form id="alert-form" class="alert-form">
+        <label>
+          Symbol
+          <input type="text" id="alert-symbol" placeholder="e.g. TSLA" required />
+        </label>
+        <label>
+          Event type
+          <select id="alert-type">
+            <option value="earnings">Earnings</option>
+            <option value="macro">Macro</option>
+            <option value="guidance">Guidance</option>
+            <option value="dividend">Dividend</option>
+          </select>
+        </label>
+        <label>
+          Notify me
+          <select id="alert-window">
+            <option value="1">1 day before</option>
+            <option value="3">3 days before</option>
+            <option value="7">1 week before</option>
+          </select>
+        </label>
+        <button type="submit">Add alert</button>
+      </form>
+
+      <div class="results-header">
+        <h3>Active alerts</h3>
+        <span id="alert-count">0</span>
+      </div>
+      <div id="alerts" class="alerts"></div>
+    </section>
+  </main>
+
+  <footer>
+    <p>Market Event Watcher is a demo app. Connect it to your data provider to go live.</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,197 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f7fb;
+  --panel: #ffffff;
+  --primary: #1f4cd6;
+  --accent: #f0b429;
+  --text: #1c1c28;
+  --muted: #6b7280;
+  --border: #e4e7ec;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.hero {
+  padding: 3rem 8vw 2rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 3vw, 3rem);
+  margin: 0 0 0.5rem;
+}
+
+.hero .subtitle {
+  max-width: 480px;
+  color: var(--muted);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.7rem;
+  color: var(--primary);
+  margin-bottom: 0.5rem;
+}
+
+.hero-card {
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 1.5rem 2rem;
+  box-shadow: 0 10px 30px rgba(31, 76, 214, 0.08);
+  min-width: 240px;
+}
+
+.hero-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+main {
+  display: grid;
+  gap: 2rem;
+  padding: 0 8vw 4rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.panel {
+  background: var(--panel);
+  border-radius: 20px;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
+}
+
+.panel h2 {
+  margin-top: 0;
+}
+
+.search-form,
+.alert-form {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+label {
+  display: grid;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+input,
+select,
+button {
+  font: inherit;
+  padding: 0.7rem 0.9rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+button {
+  background: var(--primary);
+  color: white;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(31, 76, 214, 0.2);
+}
+
+.results-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  color: var(--muted);
+}
+
+.results,
+.alerts {
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 0.5rem;
+  background: #fdfdff;
+}
+
+.card .pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(31, 76, 214, 0.08);
+  color: var(--primary);
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.card .meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.card .actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.card .actions button {
+  background: transparent;
+  color: var(--primary);
+  border: 1px solid rgba(31, 76, 214, 0.2);
+}
+
+.card .actions button:hover {
+  box-shadow: none;
+  transform: none;
+  background: rgba(31, 76, 214, 0.08);
+}
+
+.alert-card {
+  border-left: 4px solid var(--accent);
+}
+
+footer {
+  padding: 2rem 8vw 3rem;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 2.5rem 6vw 1rem;
+  }
+
+  main {
+    padding: 0 6vw 3rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, static demo for searching upcoming stock market events and creating alerts to monitor symbols and event types.

### Description
- Add a responsive static UI in `index.html` with search filters and an alert creation panel. 
- Implement client-side logic in `app.js` to store sample `events`, filter results, render event cards, and add/remove in-memory `alerts` from search results or a custom form. 
- Add styling in `styles.css` for a card-based, responsive layout and UI polish. 
- Replace the README with `README.md` documenting features, usage, and next steps to connect to a real data provider.

### Testing
- Started a local dev server with `python -m http.server 8000`, which served the static site successfully. 
- Attempted an automated Playwright screenshot run, which failed due to a browser crash (`TargetClosedError` / SIGSEGV) in this environment. 
- No unit or integration test suite was added or executed for this static demo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dd2a6bf8c833191e5ec8f3c5945c5)